### PR TITLE
added origins, civil attributes, updated info box, updated tags

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -111,6 +111,13 @@ body {
   width: 100%;
 }
 
+.origins-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+}
+
 .sheet-header {
   display: flex;
   flex-direction: column;

--- a/src/components/AttributesSection.css
+++ b/src/components/AttributesSection.css
@@ -23,8 +23,33 @@
   padding: 8px 10px;
 }
 
+.stepper-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stepper-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: #e5e7eb;
+  cursor: pointer;
+}
+
+.stepper-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .attributes-block input[type="number"]::-webkit-inner-spin-button,
 .attributes-block input[type="number"]::-webkit-outer-spin-button {
-  transform: scale(1.3);
-  margin-left: 4px;
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.attributes-block input[type="number"] {
+  -moz-appearance: textfield;
 }

--- a/src/components/AttributesSection.tsx
+++ b/src/components/AttributesSection.tsx
@@ -44,6 +44,16 @@ export function AttributesSection({
     );
   }, [attributes]);
 
+  function clamp(value: number) {
+    return Math.max(10, Math.min(50, value));
+  }
+
+  function getCurrentValue(key: AttributeKey) {
+    const n = Number(drafts[key]);
+    if (Number.isFinite(n)) return n;
+    return Number(attributes[key] ?? 10);
+  }
+
   function updateAttr(key: AttributeKey, value: string) {
     setDrafts(prev => ({
       ...prev,
@@ -63,7 +73,7 @@ export function AttributesSection({
   function commitAttr(key: AttributeKey) {
     const n = Number(drafts[key]);
     const safe = Number.isFinite(n) ? n : attributes[key];
-    const clamped = Math.max(10, Math.min(50, safe));
+    const clamped = clamp(safe);
 
     setDrafts(prev => ({
       ...prev,
@@ -78,6 +88,13 @@ export function AttributesSection({
     }
   }
 
+  function stepAttr(key: AttributeKey, delta: number) {
+    if (locked) return;
+    const current = getCurrentValue(key);
+    const next = clamp(current + delta);
+    updateAttr(key, String(next));
+  }
+
   return (
     <div className="block attributes-block">
       <div className="block-title">Attributes</div>
@@ -85,16 +102,34 @@ export function AttributesSection({
       {attributeList.map(([label, key]) => (
         <div className="field-row" key={key}>
           <label className="label">{label}:</label>
-          <input
-            className="input small-input"
-            type="number"
-            min={10}
-            max={50}
-            value={drafts[key]}
-            disabled={locked}
-            onChange={(e) => updateAttr(key, e.target.value)}
-            onBlur={() => commitAttr(key)}
-          />
+          <div className="stepper-controls">
+            <button
+              className="stepper-button"
+              type="button"
+              onClick={() => stepAttr(key, -1)}
+              disabled={locked || getCurrentValue(key) <= 10}
+            >
+              -
+            </button>
+            <input
+              className="input small-input"
+              type="number"
+              min={10}
+              max={50}
+              value={drafts[key]}
+              disabled={locked}
+              onChange={(e) => updateAttr(key, e.target.value)}
+              onBlur={() => commitAttr(key)}
+            />
+            <button
+              className="stepper-button"
+              type="button"
+              onClick={() => stepAttr(key, 1)}
+              disabled={locked || getCurrentValue(key) >= 50}
+            >
+              +
+            </button>
+          </div>
         </div>
       ))}
 

--- a/src/components/CharacterSheet.tsx
+++ b/src/components/CharacterSheet.tsx
@@ -1,15 +1,21 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   type Attributes,
   type Character,
+  type CivilAttributes,
   type CyberModSystemState,
+  type OriginSelection,
+  type TagChoices,
   type TagSelections,
   type StatusSelections,
   type WeaponConfig,
 } from "../types/character";
-import { createDefaultCyberModsState } from "../data/cyberSystems";
+import { createDefaultCyberModsState, CYBER_SYSTEMS } from "../data/cyberSystems";
+import originsData from "../data/constants/origins.json";
+import tagsData from "../data/constants/tags.json";
 
 import { AttributesSection } from "./AttributesSection";
+import { CivilAttributesSection } from "./CivilAttributesSection";
 import { TagsSection } from "./TagsSection";
 import { StatusEffectsSection } from "./StatusEffectSection";
 import { WeaponSection } from "./WeaponSection";
@@ -18,6 +24,95 @@ import { InfoAndResultSection } from "./InfoandResultSection";
 import { ReadOnlyCharacter } from "./ReadOnlyCharacter";
 import { CyberModsOverview } from "./CyberModsOverview";
 import { DiceRollSection } from "./DiceRollSection";
+import { OriginsSection } from "./OriginsSection";
+import {
+  getCivilTagBonusSources,
+  type CivilBonusSource,
+} from "../lib/civilBonuses";
+
+type TagInfo = {
+  description: string;
+  choices?: Array<{ id: string; label: string }>;
+};
+
+type TagsJson = {
+  items?: Record<string, TagInfo & { name?: string }>;
+};
+
+const TAG_INFO_BY_NAME = Object.values(
+  (tagsData as TagsJson).items ?? {}
+).reduce<Record<string, TagInfo>>((acc, item) => {
+  if (item?.name) {
+    acc[item.name] = {
+      description: item.description ?? "",
+      choices: item.choices ?? [],
+    };
+  }
+  return acc;
+}, {});
+
+const CYBERMOD_DESC_BY_NAME = CYBER_SYSTEMS.reduce<Record<string, string>>(
+  (acc, system) => {
+    system.mods.forEach(mod => {
+      if (mod.name && mod.desc) {
+        acc[mod.name] = mod.desc;
+      }
+    });
+    return acc;
+  },
+  {}
+);
+
+type OriginData = {
+  id: string;
+  grants: {
+    tags: string[];
+  };
+};
+
+const ORIGINS = (originsData as { origins: OriginData[] }).origins;
+
+function getOriginAutoTags(
+  originId: string | null,
+  choiceTags: string[]
+): string[] {
+  if (!originId) return [...choiceTags];
+  const origin = ORIGINS.find(item => item.id === originId);
+  const tags = origin?.grants?.tags ?? [];
+  return [...tags, ...choiceTags];
+}
+
+function buildSelectionInfo(character: Character): string {
+  const lines: string[] = [];
+
+  Object.values(character.cyberMods).forEach(data => {
+    (data?.slots ?? []).forEach(slot => {
+      if (!slot || slot === "None") return;
+      const desc = CYBERMOD_DESC_BY_NAME[slot];
+      lines.push(desc ? `${slot}: ${desc}` : slot);
+    });
+  });
+
+  Object.entries(character.tags).forEach(([name, active]) => {
+    if (!active) return;
+    const info = TAG_INFO_BY_NAME[name];
+    let line = info?.description ? `${name}: ${info.description}` : name;
+    const choiceId = character.tagChoices[name];
+    if (choiceId && info?.choices?.length) {
+      const choice =
+        info.choices.find(option => option.id === choiceId) ??
+        info.choices.find(option => option.label === choiceId);
+      if (choice?.label) {
+        line += ` (Choice: ${choice.label})`;
+      }
+    }
+    lines.push(line);
+  });
+
+  return lines.length > 0
+    ? lines.join("\n")
+    : "Select an item to view its description.";
+}
 
 function defaultAttributes(): Attributes {
   return {
@@ -49,8 +144,37 @@ function defaultSelections(): TagSelections {
   return {};
 }
 
+function defaultTagChoices(): TagChoices {
+  return {};
+}
+
 function defaultStatusSelections(): StatusSelections {
   return {};
+}
+
+function defaultCivilAttributes(): CivilAttributes {
+  return {
+    reputation: 0,
+    empathy: 0,
+    appeal: 0,
+    performance: 0,
+    crafting: 0,
+    driving: 0,
+    evasion: 0,
+    intimidation: 0,
+    luck: 0,
+    perception: 0,
+    persuasion: 0,
+    tolerance: 0,
+  };
+}
+
+function defaultOrigin(): OriginSelection {
+  return {
+    id: null,
+    allocations: {},
+    choiceTags: [],
+  };
 }
 
 export function CharacterSheet() {
@@ -58,20 +182,24 @@ export function CharacterSheet() {
     id: crypto.randomUUID(),
     name: "New Character",
     attributes: defaultAttributes(),
+    civilAttributes: defaultCivilAttributes(),
     tags: defaultSelections(),
+    tagChoices: defaultTagChoices(),
     statusEffects: defaultStatusSelections(),
     weapon: defaultWeapon(),
     cyberMods: createDefaultCyberModsState(),
+    origin: defaultOrigin(),
   }));
-  const [selectionInfo, setSelectionInfo] = useState(
-    "Select an item to view its description."
-  );
   const [activeTab, setActiveTab] = useState<
-    "edit" | "summary" | "cybermods" | "tags"
+    "edit" | "summary" | "cybermods" | "tags" | "origins"
   >("edit");
 
   function setAttributes(next: Attributes) {
     setCharacter(prev => ({ ...prev, attributes: next }));
+  }
+
+  function setCivilAttributes(next: CivilAttributes) {
+    setCharacter(prev => ({ ...prev, civilAttributes: next }));
   }
 
   function handleNameChange(value: string) {
@@ -84,6 +212,23 @@ export function CharacterSheet() {
       tags: {
         ...prev.tags,
         [tagName]: !prev.tags[tagName],
+      },
+      tagChoices: prev.tags[tagName]
+        ? Object.fromEntries(
+            Object.entries(prev.tagChoices).filter(
+              ([key]) => key !== tagName
+            )
+          )
+        : prev.tagChoices,
+    }));
+  }
+
+  function setTagChoice(tagName: string, choiceId: string) {
+    setCharacter(prev => ({
+      ...prev,
+      tagChoices: {
+        ...prev.tagChoices,
+        [tagName]: choiceId,
       },
     }));
   }
@@ -115,13 +260,44 @@ export function CharacterSheet() {
     }));
   }
 
-  function handleSelectionInfo(info?: string) {
-    if (info && info.trim().length > 0) {
-      setSelectionInfo(info);
-    } else {
-      setSelectionInfo("Select an item to view its description.");
-    }
+  function handleOriginConfirm(
+    nextOrigin: OriginSelection,
+    autoTags: string[]
+  ) {
+    setCharacter(prev => {
+      const nextTags = { ...prev.tags };
+      const nextChoices = { ...prev.tagChoices };
+      const previousAutoTags = getOriginAutoTags(
+        prev.origin.id,
+        prev.origin.choiceTags
+      );
+      previousAutoTags.forEach(tag => {
+        delete nextTags[tag];
+        delete nextChoices[tag];
+      });
+      autoTags.forEach(tag => {
+        nextTags[tag] = true;
+      });
+      return {
+        ...prev,
+        origin: nextOrigin,
+        tags: nextTags,
+        tagChoices: nextChoices,
+      };
+    });
   }
+
+  const civilBonusSources: CivilBonusSource[] = [
+    {
+      label: "Origin",
+      values: character.origin.allocations,
+    },
+    ...getCivilTagBonusSources(character.tags, character.tagChoices),
+  ];
+  const selectionInfo = useMemo(
+    () => buildSelectionInfo(character),
+    [character]
+  );
 
   return (
     <div className="character-sheet-wrapper">
@@ -158,6 +334,14 @@ export function CharacterSheet() {
         >
           Tags
         </button>
+        <button
+          className={`tab-button ${
+            activeTab === "origins" ? "active" : ""
+          }`}
+          onClick={() => setActiveTab("origins")}
+        >
+          Origins
+        </button>
       </div>
 
       {activeTab === "edit" ? (
@@ -180,6 +364,11 @@ export function CharacterSheet() {
               <AttributesSection
                 attributes={character.attributes}
                 onChange={setAttributes}
+              />
+              <CivilAttributesSection
+                attributes={character.civilAttributes}
+                bonusSources={civilBonusSources}
+                onChange={setCivilAttributes}
               />
               <StatusEffectsSection
                 selected={character.statusEffects}
@@ -213,16 +402,24 @@ export function CharacterSheet() {
           <CyberModsSection
             selections={character.cyberMods}
             onSystemChange={updateCyberSystem}
-            onSelectInfo={handleSelectionInfo}
           />
           <CyberModsOverview selections={character.cyberMods} />
         </div>
-      ) : (
+      ) : activeTab === "tags" ? (
         <div className="tags-tab">
           <TagsSection
             selected={character.tags}
+            choices={character.tagChoices}
             onToggle={toggleTag}
-            onSelectInfo={handleSelectionInfo}
+            onChoiceChange={setTagChoice}
+          />
+        </div>
+      ) : (
+        <div className="origins-tab">
+          <OriginsSection
+            selected={character.origin}
+            baseAttributes={character.civilAttributes}
+            onConfirm={handleOriginConfirm}
           />
         </div>
       )}

--- a/src/components/CivilAttributesSection.css
+++ b/src/components/CivilAttributesSection.css
@@ -1,0 +1,86 @@
+.civil-attributes-block {
+  background: #111827;
+  color: #e5e7eb;
+  padding: 18px 22px;
+  border-radius: 10px;
+  border: 1px solid #1f2937;
+  width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+}
+
+.civil-attributes-block .block-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.civil-attribute {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.civil-attribute:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.civil-attribute-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.stepper-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stepper-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: #e5e7eb;
+  cursor: pointer;
+}
+
+.stepper-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.civil-input {
+  width: 110px;
+  font-size: 15px;
+  padding: 6px 8px;
+}
+
+.civil-input::-webkit-inner-spin-button,
+.civil-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.civil-input {
+  -moz-appearance: textfield;
+}
+
+.civil-attribute-description {
+  font-size: 12px;
+  color: #9ca3af;
+  line-height: 1.4;
+}
+
+.civil-attribute-bonus {
+  font-size: 12px;
+  color: #93c5fd;
+}

--- a/src/components/CivilAttributesSection.tsx
+++ b/src/components/CivilAttributesSection.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState } from "react";
+import "./CivilAttributesSection.css";
+
+import type {
+  CivilAttributes,
+  CivilAttributeKey,
+} from "../types/character";
+import type { CivilBonusSource } from "../lib/civilBonuses";
+import { sumCivilBonusSources } from "../lib/civilBonuses";
+import civilData from "../data/constants/civil_attributes.json";
+
+type CivilAttributeDef = {
+  id: CivilAttributeKey;
+  name: string;
+  description: string;
+  min: number;
+  max: number;
+};
+
+type CivilJson = {
+  attributes: CivilAttributeDef[];
+};
+
+const CIVIL_ATTRIBUTES = (civilData as CivilJson).attributes;
+
+const DEFAULT_SOURCES: CivilBonusSource[] = [];
+
+function getBonus(
+  bonuses: Partial<Record<CivilAttributeKey, number>>,
+  key: CivilAttributeKey
+): number {
+  const value = bonuses[key];
+  return Number.isFinite(value) ? (value as number) : 0;
+}
+
+function getTotal(
+  base: CivilAttributes,
+  bonuses: Partial<Record<CivilAttributeKey, number>>,
+  key: CivilAttributeKey,
+  limits: { min: number; max: number }
+): number {
+  const raw = Number(base[key] ?? 0) + getBonus(bonuses, key);
+  return Math.max(limits.min, Math.min(limits.max, raw));
+}
+
+type CivilAttributesSectionProps = {
+  attributes: CivilAttributes;
+  bonusSources?: CivilBonusSource[];
+  onChange: (next: CivilAttributes) => void;
+};
+
+export function CivilAttributesSection({
+  attributes,
+  bonusSources = DEFAULT_SOURCES,
+  onChange,
+}: CivilAttributesSectionProps) {
+  const bonusTotals = useMemo(
+    () => sumCivilBonusSources(bonusSources),
+    [bonusSources]
+  );
+  const totals = useMemo(() => {
+    const next: Record<CivilAttributeKey, number> = {
+      reputation: 0,
+      empathy: 0,
+      appeal: 0,
+      performance: 0,
+      crafting: 0,
+      driving: 0,
+      evasion: 0,
+      intimidation: 0,
+      luck: 0,
+      perception: 0,
+      persuasion: 0,
+      tolerance: 0,
+    };
+    CIVIL_ATTRIBUTES.forEach(attr => {
+      next[attr.id] = getTotal(
+        attributes,
+        bonusTotals,
+        attr.id,
+        { min: attr.min, max: attr.max }
+      );
+    });
+    return next;
+  }, [attributes, bonusTotals]);
+
+  const [drafts, setDrafts] = useState<Record<CivilAttributeKey, string>>(
+    () =>
+      Object.fromEntries(
+        Object.entries(totals).map(([key, value]) => [
+          key,
+          String(value),
+        ])
+      ) as Record<CivilAttributeKey, string>
+  );
+
+  useEffect(() => {
+    setDrafts(
+      Object.fromEntries(
+        Object.entries(totals).map(([key, value]) => [
+          key,
+          String(value),
+        ])
+      ) as Record<CivilAttributeKey, string>
+    );
+  }, [totals]);
+
+  function clamp(attr: CivilAttributeDef, value: number) {
+    return Math.max(attr.min, Math.min(attr.max, value));
+  }
+
+  function getCurrentValue(attr: CivilAttributeDef) {
+    const n = Number(drafts[attr.id]);
+    if (Number.isFinite(n)) return n;
+    return getTotal(attributes, bonusTotals, attr.id, {
+      min: attr.min,
+      max: attr.max,
+    });
+  }
+
+  function updateAttr(attr: CivilAttributeDef, value: string) {
+    setDrafts(prev => ({
+      ...prev,
+      [attr.id]: value,
+    }));
+
+    const n = Number(value);
+    if (!Number.isFinite(n)) return;
+    if (n < attr.min || n > attr.max) return;
+
+    const bonus = getBonus(bonusTotals, attr.id);
+    const nextBase = n - bonus;
+    onChange({
+      ...attributes,
+      [attr.id]: nextBase,
+    });
+  }
+
+  function commitAttr(attr: CivilAttributeDef) {
+    const raw = Number(drafts[attr.id]);
+    const bonus = getBonus(bonusTotals, attr.id);
+    const currentTotal = getTotal(attributes, bonusTotals, attr.id, {
+      min: attr.min,
+      max: attr.max,
+    });
+    const safe = Number.isFinite(raw) ? raw : currentTotal;
+    const clamped = clamp(attr, safe);
+    const nextBase = clamped - bonus;
+
+    setDrafts(prev => ({
+      ...prev,
+      [attr.id]: String(clamped),
+    }));
+
+    if (nextBase !== attributes[attr.id]) {
+      onChange({
+        ...attributes,
+        [attr.id]: nextBase,
+      });
+    }
+  }
+
+  function stepAttr(attr: CivilAttributeDef, delta: number) {
+    const current = getCurrentValue(attr);
+    const next = clamp(attr, current + delta);
+    updateAttr(attr, String(next));
+  }
+
+  return (
+    <div className="civil-attributes-block">
+      <div className="block-title">Civil Attributes</div>
+
+      {CIVIL_ATTRIBUTES.map(attr => {
+        const bonusLines = bonusSources
+          .map(source => ({
+            label: source.label,
+            value: source.values[attr.id] ?? 0,
+          }))
+          .filter(entry => Number(entry.value) !== 0);
+        return (
+          <div key={attr.id} className="civil-attribute">
+            <div className="civil-attribute-header">
+              <label className="label">{attr.name}</label>
+              <div className="stepper-controls">
+                <button
+                  className="stepper-button"
+                  type="button"
+                  onClick={() => stepAttr(attr, -1)}
+                  disabled={getCurrentValue(attr) <= attr.min}
+                >
+                  -
+                </button>
+                <input
+                  className="input civil-input"
+                  type="number"
+                  min={attr.min}
+                  max={attr.max}
+                  value={drafts[attr.id]}
+                  onChange={(e) => updateAttr(attr, e.target.value)}
+                  onBlur={() => commitAttr(attr)}
+                />
+                <button
+                  className="stepper-button"
+                  type="button"
+                  onClick={() => stepAttr(attr, 1)}
+                  disabled={getCurrentValue(attr) >= attr.max}
+                >
+                  +
+                </button>
+              </div>
+            </div>
+            <div className="civil-attribute-description">
+              {attr.description}
+            </div>
+            {bonusLines.map(entry => (
+              <div
+                key={`${attr.id}-${entry.label}`}
+                className="civil-attribute-bonus"
+              >
+                {entry.label} bonus:{" "}
+                {entry.value > 0 ? "+" : ""}
+                {entry.value}
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/OriginsSection.css
+++ b/src/components/OriginsSection.css
@@ -1,0 +1,179 @@
+.origins-page {
+  color: #e5e7eb;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.origins-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #111827;
+  border: 1px solid #1f2937;
+  border-radius: 10px;
+  padding: 14px 18px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+}
+
+.origins-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.origins-points {
+  font-size: 14px;
+  color: #e2e8f0;
+}
+
+.origins-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  width: 100%;
+}
+
+.origin-card {
+  background: #111827;
+  border: 1px solid #1f2937;
+  border-radius: 10px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  cursor: pointer;
+}
+
+.origin-card.active {
+  border-color: #3b82f6;
+}
+
+.origin-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.origin-card-title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.origin-card-points {
+  font-size: 12px;
+  color: #93c5fd;
+}
+
+.origin-card-description {
+  font-size: 13px;
+  color: #cbd5f5;
+  line-height: 1.4;
+}
+
+.origin-card-meta {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.origin-card-allocation {
+  margin-top: 8px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.origin-alloc-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.origin-alloc-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.origin-alloc-label {
+  font-size: 13px;
+  text-transform: capitalize;
+}
+
+.origin-alloc-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.alloc-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: #e5e7eb;
+  cursor: pointer;
+}
+
+.alloc-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.alloc-input {
+  width: 60px;
+  text-align: center;
+  padding: 4px 6px;
+  border-radius: 6px;
+  border: 1px solid #334155;
+  background: #020617;
+  color: #e5e7eb;
+}
+
+.alloc-input::-webkit-inner-spin-button,
+.alloc-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.alloc-input {
+  -moz-appearance: textfield;
+}
+
+.origin-choice {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 12px;
+  color: #cbd5f5;
+}
+
+.origin-choice-title {
+  font-weight: 600;
+}
+
+.origin-choice-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.origin-confirm {
+  align-self: flex-start;
+  margin-top: 6px;
+}
+
+.origin-confirm:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.origin-choice-warning {
+  font-size: 12px;
+  color: #fca5a5;
+}

--- a/src/components/OriginsSection.tsx
+++ b/src/components/OriginsSection.tsx
@@ -1,0 +1,350 @@
+import { useEffect, useMemo, useState } from "react";
+import "./OriginsSection.css";
+
+import originsData from "../data/constants/origins.json";
+import civilData from "../data/constants/civil_attributes.json";
+import type {
+  CivilAttributeKey,
+  CivilAttributes,
+  OriginSelection,
+} from "../types/character";
+
+type OriginChoice = {
+  choose: number;
+  options: string[];
+};
+
+type Origin = {
+  id: string;
+  name: string;
+  description: string;
+  bonusPoints: {
+    amount: number;
+    spendOn: string[];
+  };
+  grants: {
+    tags: string[];
+    choices: OriginChoice[];
+  };
+  recommendedFor: string[];
+};
+
+type OriginsJson = {
+  origins: Origin[];
+};
+
+type CivilAttributeDef = {
+  id: CivilAttributeKey;
+  name: string;
+  min: number;
+  max: number;
+};
+
+type CivilJson = {
+  attributes: CivilAttributeDef[];
+};
+
+const ORIGINS = (originsData as OriginsJson).origins;
+const CIVIL_ATTRS = (civilData as CivilJson).attributes;
+
+const CIVIL_LIMITS = CIVIL_ATTRS.reduce<
+  Record<CivilAttributeKey, { min: number; max: number }>
+>((acc, attr) => {
+  acc[attr.id] = { min: attr.min, max: attr.max };
+  return acc;
+}, {} as Record<CivilAttributeKey, { min: number; max: number }>);
+
+const NAME_TO_KEY: Record<string, CivilAttributeKey> = {
+  Reputation: "reputation",
+  Empathy: "empathy",
+  Appeal: "appeal",
+  Performance: "performance",
+  Crafting: "crafting",
+  Driving: "driving",
+  Evasion: "evasion",
+  Intimidation: "intimidation",
+  Luck: "luck",
+  Perception: "perception",
+  Persuasion: "persuasion",
+  Tolerance: "tolerance",
+};
+
+const EMPTY_ALLOCATIONS: Partial<Record<CivilAttributeKey, number>> = {};
+
+type OriginsSectionProps = {
+  selected: OriginSelection;
+  baseAttributes: CivilAttributes;
+  onConfirm: (next: OriginSelection, autoTags: string[]) => void;
+};
+
+export function OriginsSection({
+  selected,
+  baseAttributes,
+  onConfirm,
+}: OriginsSectionProps) {
+  const [activeId, setActiveId] = useState<string | null>(
+    selected.id
+  );
+  const [draftAllocations, setDraftAllocations] = useState<
+    Partial<Record<CivilAttributeKey, number>>
+  >(selected.allocations ?? EMPTY_ALLOCATIONS);
+  const [choiceSelections, setChoiceSelections] = useState<
+    Record<number, string>
+  >({});
+
+  useEffect(() => {
+    setActiveId(selected.id);
+    setDraftAllocations(selected.allocations ?? EMPTY_ALLOCATIONS);
+    const nextChoices: Record<number, string> = {};
+    selected.choiceTags.forEach((tag, index) => {
+      nextChoices[index] = tag;
+    });
+    setChoiceSelections(nextChoices);
+  }, [selected]);
+
+  const activeOrigin = useMemo(
+    () => ORIGINS.find(origin => origin.id === activeId) ?? null,
+    [activeId]
+  );
+
+  const spendableKeys = useMemo(() => {
+    if (!activeOrigin) return [] as CivilAttributeKey[];
+    return activeOrigin.bonusPoints.spendOn
+      .map(name => NAME_TO_KEY[name])
+      .filter(Boolean) as CivilAttributeKey[];
+  }, [activeOrigin]);
+
+  const spentPoints = spendableKeys.reduce((sum, key) => {
+    return sum + (draftAllocations[key] ?? 0);
+  }, 0);
+  const choicesComplete = activeOrigin
+    ? activeOrigin.grants.choices.every((_, idx) =>
+        Boolean(choiceSelections[idx])
+      )
+    : true;
+
+  function handleSelect(origin: Origin) {
+    setActiveId(origin.id);
+    if (origin.id === selected.id) {
+      setDraftAllocations(selected.allocations ?? EMPTY_ALLOCATIONS);
+    } else {
+      setDraftAllocations({});
+      setChoiceSelections({});
+    }
+  }
+
+  function updateAllocation(
+    key: CivilAttributeKey,
+    nextValue: number
+  ) {
+    if (!activeOrigin) return;
+    const current = draftAllocations[key] ?? 0;
+    const totalWithoutCurrent = spentPoints - current;
+    const maxByPool = activeOrigin.bonusPoints.amount - totalWithoutCurrent;
+
+    const base = Number(baseAttributes[key] ?? 0);
+    const limits = CIVIL_LIMITS[key] ?? { min: -10, max: 10 };
+    const maxByCap = limits.max - base;
+
+    const allowedMax = Math.max(0, Math.min(maxByPool, maxByCap));
+    const clamped = Math.max(0, Math.min(allowedMax, nextValue));
+
+    setDraftAllocations(prev => ({
+      ...prev,
+      [key]: clamped,
+    }));
+  }
+
+  function handleConfirm() {
+    if (!activeOrigin) return;
+    const normalized: Partial<Record<CivilAttributeKey, number>> = {};
+    spendableKeys.forEach(key => {
+      const value = draftAllocations[key] ?? 0;
+      if (value > 0) {
+        normalized[key] = value;
+      }
+    });
+
+    const chosenTags = Object.values(choiceSelections).filter(Boolean);
+    const autoTags = [
+      ...(activeOrigin.grants.tags ?? []),
+      ...chosenTags,
+    ];
+
+    onConfirm(
+      {
+        id: activeOrigin.id,
+        allocations: normalized,
+        choiceTags: chosenTags,
+      },
+      autoTags
+    );
+  }
+
+  return (
+    <div className="origins-page">
+      <div className="origins-header">
+        <div className="origins-title">Origins</div>
+        {activeOrigin ? (
+          <div className="origins-points">
+            {spentPoints} / {activeOrigin.bonusPoints.amount} points
+            allocated
+          </div>
+        ) : (
+          <div className="origins-points">Select an origin</div>
+        )}
+      </div>
+
+      <div className="origins-grid">
+        {ORIGINS.map(origin => {
+          const isActive = origin.id === activeId;
+          return (
+            <div
+              key={origin.id}
+              className={`origin-card ${isActive ? "active" : ""}`}
+              onClick={() => handleSelect(origin)}
+            >
+              <div className="origin-card-header">
+                <div className="origin-card-title">{origin.name}</div>
+                <div className="origin-card-points">
+                  +{origin.bonusPoints.amount} points
+                </div>
+              </div>
+              <div className="origin-card-description">
+                {origin.description}
+              </div>
+              <div className="origin-card-meta">
+                <strong>Spend On:</strong> {origin.bonusPoints.spendOn.join(", ")}
+              </div>
+              {origin.grants.tags.length > 0 && (
+                <div className="origin-card-meta">
+                  <strong>Grants:</strong> {origin.grants.tags.join(", ")}
+                </div>
+              )}
+              {origin.recommendedFor.length > 0 && (
+                <div className="origin-card-meta">
+                  <strong>Recommended:</strong> {origin.recommendedFor.join(", ")}
+                </div>
+              )}
+
+              {isActive && (
+                <div className="origin-card-allocation">
+                  <div className="origin-alloc-title">
+                    Allocate points
+                  </div>
+                  {spendableKeys.map(key => {
+                    const current = draftAllocations[key] ?? 0;
+                    const limits = CIVIL_LIMITS[key];
+                    const base = Number(baseAttributes[key] ?? 0);
+                    const maxByCap = limits.max - base;
+                    const totalWithoutCurrent = spentPoints - current;
+                    const maxByPool =
+                      origin.bonusPoints.amount - totalWithoutCurrent;
+                    const allowedMax = Math.max(
+                      0,
+                      Math.min(maxByPool, maxByCap)
+                    );
+
+                    return (
+                      <div key={key} className="origin-alloc-row">
+                        <span className="origin-alloc-label">
+                          {key.charAt(0).toUpperCase() + key.slice(1)}
+                        </span>
+                        <div className="origin-alloc-controls">
+                          <button
+                            className="alloc-button"
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              updateAllocation(key, current - 1);
+                            }}
+                            disabled={current <= 0}
+                          >
+                            -
+                          </button>
+                          <input
+                            className="alloc-input"
+                            type="number"
+                            min={0}
+                            max={allowedMax}
+                            value={current}
+                            readOnly
+                            onClick={e => e.stopPropagation()}
+                            onChange={(e) => {
+                              e.stopPropagation();
+                              updateAllocation(key, Number(e.target.value));
+                            }}
+                          />
+                          <button
+                            className="alloc-button"
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              updateAllocation(key, current + 1);
+                            }}
+                            disabled={current >= allowedMax}
+                          >
+                            +
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+
+                  {origin.grants.choices.length > 0 && (
+                    <div className="origin-choice">
+                      {origin.grants.choices.map((choice, idx) => (
+                        <div key={`${origin.id}-choice-${idx}`}>
+                          <div className="origin-choice-title">
+                            Choose {choice.choose}
+                          </div>
+                          {choice.options.map(option => (
+                            <label
+                              key={option}
+                              className="origin-choice-option"
+                              onClick={e => e.stopPropagation()}
+                            >
+                              <input
+                                type="radio"
+                                name={`${origin.id}-choice-${idx}`}
+                                checked={choiceSelections[idx] === option}
+                                onChange={() =>
+                                  setChoiceSelections(prev => ({
+                                    ...prev,
+                                    [idx]: option,
+                                  }))
+                                }
+                              />
+                              <span>{option}</span>
+                            </label>
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  <button
+                    className="button origin-confirm"
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleConfirm();
+                    }}
+                    disabled={!choicesComplete}
+                  >
+                    Confirm Origin
+                  </button>
+                  {!choicesComplete && (
+                    <div className="origin-choice-warning">
+                      Select a tag choice to confirm.
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TagsSection.css
+++ b/src/components/TagsSection.css
@@ -62,14 +62,20 @@
 
 .tag-row {
   display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 6px;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 10px;
   font-size: 13px;
   cursor: pointer;
 }
 
-.tag-row input {
+.tag-row-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.tag-row-main input {
   margin-top: 2px;
 }
 
@@ -85,4 +91,29 @@
 .tag-description {
   font-size: 12px;
   color: #9ca3af;
+}
+
+.tag-choices {
+  margin-left: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #cbd5f5;
+}
+
+.tag-choices-title {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.tag-choice-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tag-choice-warning {
+  color: #fca5a5;
+  font-size: 11px;
 }

--- a/src/components/TagsSection.tsx
+++ b/src/components/TagsSection.tsx
@@ -1,6 +1,6 @@
 import "./TagsSection.css";
 import tagsData from "../data/constants/tags.json";
-import type { TagSelections } from "../types/character";
+import type { TagChoices, TagSelections } from "../types/character";
 
 type TagItem = {
   name: string;
@@ -8,6 +8,10 @@ type TagItem = {
   categoryId: string;
   cost: string;
   description: string;
+  choices?: Array<{
+    id: string;
+    label: string;
+  }>;
   effects?: unknown[];
 };
 
@@ -53,13 +57,17 @@ const UNCATEGORIZED_TAGS = TAG_ITEMS.filter(
 
 type TagsSectionProps = {
   selected: TagSelections;
+  choices: TagChoices;
   onToggle: (tagName: string) => void;
+  onChoiceChange: (tagName: string, choiceId: string) => void;
   onSelectInfo?: (info: string) => void;
 };
 
 export function TagsSection({
   selected,
+  choices,
   onToggle,
+  onChoiceChange,
   onSelectInfo,
 }: TagsSectionProps) {
   const totalCost = TAG_ITEMS.reduce((sum, item) => {
@@ -86,26 +94,60 @@ export function TagsSection({
           <div key={category.id} className="tag-card">
             <div className="tag-card-title">{category.name}</div>
             <div className="tag-card-list">
-              {category.items.map(item => (
-                <label key={item.id} className="tag-row">
-                  <input
-                    type="checkbox"
-                    checked={!!selected[item.name]}
-                    onChange={() => {
-                      onToggle(item.name);
-                      onSelectInfo?.(
-                        `${item.name}: ${item.description}`
-                      );
-                    }}
-                  />
-                  <div className="tag-text">
-                    <div className="tag-name">{item.name}</div>
-                    <div className="tag-description">
-                      {item.description}
-                    </div>
+              {category.items.map(item => {
+                const isSelected = Boolean(selected[item.name]);
+                const choiceId = choices[item.name] ?? "";
+                return (
+                  <div key={item.id} className="tag-row">
+                    <label className="tag-row-main">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => {
+                          onToggle(item.name);
+                          onSelectInfo?.(
+                            `${item.name}: ${item.description}`
+                          );
+                        }}
+                      />
+                      <div className="tag-text">
+                        <div className="tag-name">{item.name}</div>
+                        <div className="tag-description">
+                          {item.description}
+                        </div>
+                      </div>
+                    </label>
+                    {isSelected && item.choices?.length ? (
+                      <div className="tag-choices">
+                        <div className="tag-choices-title">
+                          Choose one:
+                        </div>
+                        {item.choices.map(choice => (
+                          <label
+                            key={`${item.id}-${choice.id}`}
+                            className="tag-choice-option"
+                          >
+                            <input
+                              type="radio"
+                              name={`tag-choice-${item.id}`}
+                              checked={choiceId === choice.id}
+                              onChange={() =>
+                                onChoiceChange(item.name, choice.id)
+                              }
+                            />
+                            <span>{choice.label}</span>
+                          </label>
+                        ))}
+                        {!choiceId && (
+                          <div className="tag-choice-warning">
+                            Select a bonus to apply.
+                          </div>
+                        )}
+                      </div>
+                    ) : null}
                   </div>
-                </label>
-              ))}
+                );
+              })}
             </div>
           </div>
         ))}
@@ -113,26 +155,60 @@ export function TagsSection({
           <div className="tag-card">
             <div className="tag-card-title">Uncategorized</div>
             <div className="tag-card-list">
-              {UNCATEGORIZED_TAGS.map(item => (
-                <label key={item.id} className="tag-row">
-                  <input
-                    type="checkbox"
-                    checked={!!selected[item.name]}
-                    onChange={() => {
-                      onToggle(item.name);
-                      onSelectInfo?.(
-                        `${item.name}: ${item.description}`
-                      );
-                    }}
-                  />
-                  <div className="tag-text">
-                    <div className="tag-name">{item.name}</div>
-                    <div className="tag-description">
-                      {item.description}
+            {UNCATEGORIZED_TAGS.map(item => {
+              const isSelected = Boolean(selected[item.name]);
+              const choiceId = choices[item.name] ?? "";
+              return (
+                <div key={item.id} className="tag-row">
+                  <label className="tag-row-main">
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => {
+                        onToggle(item.name);
+                        onSelectInfo?.(
+                          `${item.name}: ${item.description}`
+                        );
+                      }}
+                    />
+                    <div className="tag-text">
+                      <div className="tag-name">{item.name}</div>
+                      <div className="tag-description">
+                        {item.description}
+                      </div>
                     </div>
-                  </div>
-                </label>
-              ))}
+                  </label>
+                  {isSelected && item.choices?.length ? (
+                    <div className="tag-choices">
+                      <div className="tag-choices-title">
+                        Choose one:
+                      </div>
+                      {item.choices.map(choice => (
+                        <label
+                          key={`${item.id}-${choice.id}`}
+                          className="tag-choice-option"
+                        >
+                          <input
+                            type="radio"
+                            name={`tag-choice-${item.id}`}
+                            checked={choiceId === choice.id}
+                            onChange={() =>
+                              onChoiceChange(item.name, choice.id)
+                            }
+                          />
+                          <span>{choice.label}</span>
+                        </label>
+                      ))}
+                      {!choiceId && (
+                        <div className="tag-choice-warning">
+                          Select a bonus to apply.
+                        </div>
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
             </div>
           </div>
         )}

--- a/src/components/WeaponSection.css
+++ b/src/components/WeaponSection.css
@@ -47,6 +47,37 @@
   flex: 1.2;
 }
 
+.stepper-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stepper-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid #334155;
+  background: #0f172a;
+  color: #e5e7eb;
+  cursor: pointer;
+}
+
+.stepper-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.weapon-damage-input::-webkit-inner-spin-button,
+.weapon-damage-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.weapon-damage-input {
+  -moz-appearance: textfield;
+}
+
 /* Flags */
 .weapon-flags {
   display: flex;

--- a/src/components/WeaponSection.tsx
+++ b/src/components/WeaponSection.tsx
@@ -88,6 +88,12 @@ export function WeaponSection({
     updateWeapon({ damage: Math.max(0, Math.min(1000, value)) });
   }
 
+  function stepDamage(delta: number) {
+    if (isUnarmed) return;
+    const next = Math.max(0, Math.min(1000, weapon.damage + delta));
+    updateWeapon({ damage: next });
+  }
+
   function handleTypeChange(nextType: WeaponType) {
     updateWeapon({
       type: nextType,
@@ -124,15 +130,33 @@ export function WeaponSection({
       {/* Weapon Damage */}
       <div className="field-row">
         <label className="label">Weapon Damage</label>
-        <input
-          type="number"
-          min={0}
-          max={1000}
-          className="input small-input"
-          value={weapon.damage}
-          onChange={handleDamageChange}
-          disabled={isUnarmed}
-        />
+        <div className="stepper-controls">
+          <button
+            className="stepper-button"
+            type="button"
+            onClick={() => stepDamage(-1)}
+            disabled={isUnarmed || weapon.damage <= 0}
+          >
+            -
+          </button>
+          <input
+            type="number"
+            min={0}
+            max={1000}
+            className="input small-input weapon-damage-input"
+            value={weapon.damage}
+            onChange={handleDamageChange}
+            disabled={isUnarmed}
+          />
+          <button
+            className="stepper-button"
+            type="button"
+            onClick={() => stepDamage(1)}
+            disabled={isUnarmed || weapon.damage >= 1000}
+          >
+            +
+          </button>
+        </div>
       </div>
 
       {/* Flags */}

--- a/src/data/constants/civil_attributes.json
+++ b/src/data/constants/civil_attributes.json
@@ -1,0 +1,88 @@
+{
+  "attributes": [
+    {
+      "id": "reputation",
+      "name": "Reputation",
+      "description": "Impacts relations and affinity with strangers. Gain better cuts of rewards, though expectations become higher. Every 100 points increases Reputation Roll by +1.",
+      "min": -500,
+      "max": 500
+    },
+    {
+      "id": "empathy",
+      "name": "Empathy",
+      "description": "Impacts ability to work well with allies and reap better non-Eurodollar rewards. Modified by certain player actions. Helps prevent Cyber Psychosis.",
+      "min": -500,
+      "max": 500
+    },
+    {
+      "id": "appeal",
+      "name": "Appeal",
+      "description": "Base rating of how much you appeal to others.",
+      "min": -10,
+      "max": 10
+    },
+    {
+      "id": "performance",
+      "name": "Performance",
+      "description": "Skill of performing in front of others, such as singing, acting, playing an instrument, or speaking.",
+      "min": -10,
+      "max": 10
+    },
+    {
+      "id": "crafting",
+      "name": "Crafting",
+      "description": "Ability to craft items properly. Knowledge is required to craft certain items. Higher crafting allows for rarer and stronger items.",
+      "min": 0,
+      "max": 20
+    },
+    {
+      "id": "driving",
+      "name": "Driving",
+      "description": "Skill of driving in general.",
+      "min": 0,
+      "max": 20
+    },
+    {
+      "id": "evasion",
+      "name": "Evasion",
+      "description": "Skill of not being noticed or seen.",
+      "min": -10,
+      "max": 10
+    },
+    {
+      "id": "intimidation",
+      "name": "Intimidation",
+      "description": "Base rating of your ability to intimidate others. The floor to succeeding Intimidation checks starts at 1 unless the other party has a negative trait reducing this.",
+      "min": -10,
+      "max": 10
+    },
+    {
+      "id": "luck",
+      "name": "Luck",
+      "description": "Allows you to expend Luck to ensure a skill succeeds once per session. Can also guarantee a crit attack.",
+      "min": 0,
+      "max": 100
+    },
+    {
+      "id": "perception",
+      "name": "Perception",
+      "description": "Negates from Evasion during Evasion-related checks.",
+      "min": -10,
+      "max": 10
+    },
+    {
+      "id": "persuasion",
+      "name": "Persuasion",
+      "description": "Base rating of your ability to persuade others. The floor to succeeding Persuasion checks starts at 1 unless the other party has a negative trait reducing this.",
+      "min": -10,
+      "max": 10
+    },
+    {
+      "id": "tolerance",
+      "name": "Tolerance",
+      "description": "Ability to handle pain and the effects of drugs.",
+      "min": -10,
+      "max": 10
+    }
+  ]
+}

--- a/src/data/constants/origins.json
+++ b/src/data/constants/origins.json
@@ -1,0 +1,112 @@
+{
+  "origins": [
+    {
+      "id": "corpo",
+      "name": "Corpo",
+      "description": "The higher up the corporate ladder, the less disposable someone becomes in the new world. Being someone that's not as disposable ironically makes for a larger crosshair, wherein many attempted assassinations may have taken place. This life path is for the high rollers who strive to live a boujee lifestyle.",
+      "bonusPoints": {
+        "amount": 4,
+        "spendOn": ["Appeal", "Intimidation", "Luck", "Persuasion"]
+      },
+      "grants": {
+        "tags": ["Basic Education"],
+        "choices": []
+      },
+      "recommendedFor": ["Solos", "Defiants", "Fixers", "Netrunners", "Techies"]
+    },
+    {
+      "id": "nomad",
+      "name": "Nomad",
+      "description": "Nomads live outside the main cities in abandoned lands. Their lifestyle is comparable to wolves in a pack, where the main concern is community and second to that, everything else. Their lives are often on the road, so they are always moving place to place communally, with no real home territory. Nomads are glued to their values more so than others, and this path is recommended for those from lower-class rural areas.",
+      "bonusPoints": {
+        "amount": 4,
+        "spendOn": ["Crafting", "Driving", "Evasion", "Perception"]
+      },
+      "grants": {
+        "tags": ["Driving", "Hiding/ Evading"],
+        "choices": []
+      },
+      "recommendedFor": ["Solos", "Fixers", "Netrunners", "Techies"]
+    },
+    {
+      "id": "streetkid",
+      "name": "Streetkid",
+      "description": "Born from the streets, likely in urbanity, the streetkid is not off the beaten path. Growing up with local gangs and drugs, trading braindances, and salvaging their way towards self-discovery is not an easy task. If anyone has shown resilience, it's the streetkids who made it out of the slums and have started their own lives, all feeding into the same system.",
+      "bonusPoints": {
+        "amount": 4,
+        "spendOn": ["Driving", "Evasion", "Perception", "Tolerance"]
+      },
+      "grants": {
+        "tags": ["Basic Education"],
+        "choices": []
+      },
+      "recommendedFor": ["Solos", "Fixers", "Netrunners", "Techies"]
+    },
+    {
+      "id": "beat_cop",
+      "name": "Beat Cop",
+      "description": "This origin is best suited for a character with previous warfare experience, many of which have had to undergo transformations in order to fulfill their role as a protector. Despite this, much of the time, cops are laid off after being seen as inadequate; whether it's on behalf of their mental health, physical ability, or even outdated cyberware. The unluckiest of which are those who are tasked with the role of the Psycho Squad, where many die in combat with cyberpsychos.",
+      "bonusPoints": {
+        "amount": 4,
+        "spendOn": ["Driving", "Intimidation", "Perception", "Tolerance"]
+      },
+      "grants": {
+        "tags": ["Basic Education"],
+        "choices": []
+      },
+      "recommendedFor": ["Solos", "Fixers", "Techies"]
+    },
+    {
+      "id": "joytoy",
+      "name": "Joytoy",
+      "description": "Joytoys are sex-workers who are admired almost exclusively for their bodies, sexual, or social ability. In a world where organs are of more use than ability, joytoys have to resort to making money using their sexual services. Some joytoys have different origins, with many forced to become joytoys against their wills, due to human trafficking.",
+      "bonusPoints": {
+        "amount": 4,
+        "spendOn": ["Appeal", "Persuasion", "Tolerance", "Evasion"]
+      },
+      "grants": {
+        "tags": [],
+        "choices": [
+          {
+            "choose": 1,
+            "options": ["Attractive", "Drug/Torture Tolerance"]
+          }
+        ]
+      },
+      "recommendedFor": ["Solos", "Defiants", "Netrunners", "Techies"]
+    },
+    {
+      "id": "netwerp",
+      "name": "Netwerp",
+      "description": "Architects of the Blackwall, a Netwerp is a shut-in that undergoes the task of excavating previous excerpts of the internet. Much of their time is spent exploring forums, playing video games, or experiencing their favorite braindances. Though they are frowned upon by society, due to the statistics associated with them (low birth rate, high depression, low functionality and conventional understanding of the world), they do have their purposes on the Net but don't fit in the surface-world.",
+      "bonusPoints": {
+        "amount": 4,
+        "spendOn": ["Crafting", "Evasion", "Luck", "Tolerance"]
+      },
+      "grants": {
+        "tags": ["Basic Education"],
+        "choices": []
+      },
+      "recommendedFor": ["Solos", "Defiants", "Netrunners", "Techies"]
+    },
+    {
+      "id": "parasite",
+      "name": "Parasite",
+      "description": "Products of nepotism and the won system, Parasites find themselves contributing to no other faction from pollution itself, crashing luxury cars in public areas and traveling exclusively by Aerodynes. While they are seen as the spoiled brats, they are commonly the most likely to become successful in the entertainment industries, with much of their time dedicated to performance and free-time.",
+      "bonusPoints": {
+        "amount": 4,
+        "spendOn": ["Appeal", "Intimidation", "Luck", "Performance"]
+      },
+      "grants": {
+        "tags": [],
+        "choices": [
+          {
+            "choose": 1,
+            "options": ["Social", "Debate"]
+          }
+        ]
+      },
+      "recommendedFor": ["Solos", "Fixers", "Netrunners", "Techies"]
+    }
+  ]
+}

--- a/src/data/constants/tags.json
+++ b/src/data/constants/tags.json
@@ -164,7 +164,15 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Withstand pain or hardship. Go longer without food, sleep, or water. [+2 Tolerance]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.tolerance",
+          "op": "add",
+          "value": 2,
+          "cap": 50
+        }
+      ]
     },
     "intimidating": {
       "name": "Intimidating",
@@ -172,7 +180,15 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Intimidate others by force of personality or physical coercion. [+2 Intimidation]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.intimidation",
+          "op": "add",
+          "value": 2,
+          "cap": 50
+        }
+      ]
     },
     "drug_torture_tolerance": {
       "name": "Drug/Torture Tolerance",
@@ -180,7 +196,15 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Withstand drugs or harsh pain. Cannot be drugged or black-out drunk. [+2 Tolerance]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.tolerance",
+          "op": "add",
+          "value": 2,
+          "cap": 50
+        }
+      ]
     },
     "human_perception": {
       "name": "Human Perception",
@@ -188,7 +212,15 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Detect lies, evasions, moods, and emotional clues from others. [+2 Perception]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.perception",
+          "op": "add",
+          "value": 2,
+          "cap": 50
+        }
+      ]
     },
     "leadership": {
       "name": "Leadership",
@@ -196,7 +228,69 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Lead and convince people to follow you. [+1 Persuasion, +1 Intimidation. One may be substituted for +1 Appeal]",
-      "effects": []
+      "effects": [],
+      "choices": [
+        {
+          "id": "persuasion_intimidation",
+          "label": "+1 Persuasion, +1 Intimidation",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.persuasion",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            },
+            {
+              "kind": "stat",
+              "target": "civil.intimidation",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            }
+          ]
+        },
+        {
+          "id": "appeal_intimidation",
+          "label": "+1 Appeal, +1 Intimidation",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.appeal",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            },
+            {
+              "kind": "stat",
+              "target": "civil.intimidation",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            }
+          ]
+        },
+        {
+          "id": "appeal_persuasion",
+          "label": "+1 Appeal, +1 Persuasion",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.appeal",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            },
+            {
+              "kind": "stat",
+              "target": "civil.persuasion",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            }
+          ]
+        }
+      ]
     },
     "social": {
       "name": "Social",
@@ -204,7 +298,35 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Deal with social situations. [+2 Persuasion or +2 Appeal]",
-      "effects": []
+      "effects": [],
+      "choices": [
+        {
+          "id": "persuasion",
+          "label": "+2 Persuasion",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.persuasion",
+              "op": "add",
+              "value": 2,
+              "cap": 50
+            }
+          ]
+        },
+        {
+          "id": "appeal",
+          "label": "+2 Appeal",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.appeal",
+              "op": "add",
+              "value": 2,
+              "cap": 50
+            }
+          ]
+        }
+      ]
     },
     "debate": {
       "name": "Debate",
@@ -212,7 +334,35 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Convince others to see your viewpoint. [+2 Intimidation or Persuasion]",
-      "effects": []
+      "effects": [],
+      "choices": [
+        {
+          "id": "intimidation",
+          "label": "+2 Intimidation",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.intimidation",
+              "op": "add",
+              "value": 2,
+              "cap": 50
+            }
+          ]
+        },
+        {
+          "id": "persuasion",
+          "label": "+2 Persuasion",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.persuasion",
+              "op": "add",
+              "value": 2,
+              "cap": 50
+            }
+          ]
+        }
+      ]
     },
     "pick_pocket": {
       "name": "Pick Pocket",
@@ -220,7 +370,22 @@
       "categoryId": "body_cool_willpower",
       "cost": "++",
       "description": "Pick pockets or shoplift unnoticed. [+1 Perception, +1 Evasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.perception",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        },
+        {
+          "kind": "stat",
+          "target": "civil.evasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "anthropology_expertise": {
       "name": "Anthropology Expertise",
@@ -228,7 +393,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Knowledge of human cultures, habits, and customs. Grants knowledge of Anthropology. [+1 Luck]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.luck",
+          "op": "add",
+          "value": 1,
+          "cap": 100
+        }
+      ]
     },
     "artificial_intelligence_expertise": {
       "name": "Artificial Intelligence Expertise",
@@ -252,7 +425,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Knowledge of animals, plants, and biological systems. Grants knowledge of Biology. [+1 Persuasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.persuasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "botany": {
       "name": "Botany",
@@ -260,7 +441,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Knowledge of plants and identification. Grants knowledge of Botany. [+1 Tolerance]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.tolerance",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "chemistry": {
       "name": "Chemistry",
@@ -268,7 +457,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Skill for mixing chemicals and creating compounds. Grants knowledge of Chemistry. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "composition": {
       "name": "Composition",
@@ -276,7 +473,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Skill for writing songs, articles, or stories. Grants knowledge of Writing. [+1 Performance]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.performance",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "clever": {
       "name": "Clever",
@@ -292,7 +497,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Skill to become a professional dancer. Grants knowledge of Choreography. [+1 Performance]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.performance",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "demolitions": {
       "name": "Demolitions",
@@ -300,7 +513,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Knowledgeable in explosives and their best uses. Grants knowledge of Demolitions. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "driving": {
       "name": "Driving",
@@ -308,7 +529,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Pilot vehicles like cars, trucks, tanks, and hovercraft. Grants knowledge of Driving. [+1 Driving]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.driving",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "motorcycles": {
       "name": "Motorcycles",
@@ -316,7 +545,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Operate motorcycles, cyberbikes, and other two and three-wheeled vehicles. Grants knowledge of Motorcycles. [+1 Driving]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.driving",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "heavy_machinery": {
       "name": "Heavy Machinery",
@@ -324,7 +561,15 @@
       "categoryId": "int_tech_skill",
       "cost": "++",
       "description": "Operate watercraft, tractors, tanks, and construction equipment. Grants knowledge of Heavy Machinery. [+2 Driving]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.driving",
+          "op": "add",
+          "value": 2,
+          "cap": 50
+        }
+      ]
     },
     "piloting": {
       "name": "Piloting",
@@ -332,7 +577,15 @@
       "categoryId": "int_tech_skill",
       "cost": "++",
       "description": "Control aircraft. Grants knowledge of Aircraft. [+2 Driving]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.driving",
+          "op": "add",
+          "value": 2,
+          "cap": 50
+        }
+      ]
     },
     "health_education": {
       "name": "Health Education",
@@ -340,7 +593,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Clinically diagnose symptoms and medical problems. Grants knowledge of Health. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "basic_education": {
       "name": "Basic Education",
@@ -392,7 +653,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Build or repair simple mechanical and electrical devices. Grants knowledge of Technology. [+1 Evasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.evasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "cyberdeck_design": {
       "name": "Cyberdeck Design",
@@ -400,7 +669,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Design Cyberdecks. Grants knowledge of Cyberdeck Design. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "cybertech": {
       "name": "CyberTech",
@@ -408,7 +685,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Repair and maintain cyberwear. Grants knowledge of CyberTech. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "electronics": {
       "name": "Electronics",
@@ -416,7 +701,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Maintain, repair, and modify electronic instruments. Grants knowledge of Electronics. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "electronic_security": {
       "name": "Electronic Security",
@@ -424,7 +717,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Install or counter electronic eyes, locks, bugs, tracers, and security systems. Grants knowledge of Electronic Security. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "gambling": {
       "name": "Gambling",
@@ -432,7 +733,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Make bets, figure odds, and play games of chance. Grants knowledge of Gambling. [+1 Luck]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.luck",
+          "op": "add",
+          "value": 1,
+          "cap": 100
+        }
+      ]
     },
     "geology": {
       "name": "Geology",
@@ -440,7 +749,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Knowledge of rocks, minerals, and geological structures. Grants knowledge of Geology. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "hiding_evading": {
       "name": "Hiding/ Evading",
@@ -448,7 +765,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Lose pursuers, cover tracks, and evade people on your trail. [+1 Evasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.evasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "history": {
       "name": "History",
@@ -456,7 +781,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Knowledge of facts and figures of past events. Grants knowledge of History. [+1 Persuasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.persuasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "language": {
       "name": "Language",
@@ -464,7 +797,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Speak one language (English, German, Swedish, Japanese, Korean, Micronesian, Hawaiian, French, Italian, Portuguese, Spanish, Latin, Mandarin, Russian). [+1 Persuasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.persuasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "researcher": {
       "name": "Researcher",
@@ -472,7 +813,35 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Use databases and understand statistics. [+1 Crafting or Persuasion]",
-      "effects": []
+      "effects": [],
+      "choices": [
+        {
+          "id": "crafting",
+          "label": "+1 Crafting",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.crafting",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            }
+          ]
+        },
+        {
+          "id": "persuasion",
+          "label": "+1 Persuasion",
+          "effects": [
+            {
+              "kind": "stat",
+              "target": "civil.persuasion",
+              "op": "add",
+              "value": 1,
+              "cap": 50
+            }
+          ]
+        }
+      ]
     },
     "mathematics": {
       "name": "Mathematics",
@@ -480,7 +849,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Understand calculations and mathematical formulas. Grants knowledge of Mathematics. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "physics": {
       "name": "Physics",
@@ -488,7 +865,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Calculate physical principles like gas pressures and mechanical energies. Grants knowledge of Physics. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "photography": {
       "name": "Photography",
@@ -496,7 +881,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Produce professional-caliber photographs or motion pictures. Grants knowledge of Photography. [+1 Appeal]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.appeal",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "programming": {
       "name": "Programming",
@@ -504,7 +897,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Write programs and re-program computer systems. Grants knowledge of Programming. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "hunting": {
       "name": "Hunting",
@@ -512,7 +913,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Shadow and follow people. Grants knowledge of Hunting. [+1 Perception]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.perception",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "stock_market": {
       "name": "Stock Market",
@@ -528,7 +937,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Knowledge of the Net and its history. Grants knowledge of Net. [+1 Evasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.evasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "survival_knowledge": {
       "name": "Survival Knowledge",
@@ -536,7 +953,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Know how to survive in the wilds. Grants knowledge of Survival. [+1 Luck]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.luck",
+          "op": "add",
+          "value": 1,
+          "cap": 100
+        }
+      ]
     },
     "weaponsmith": {
       "name": "Weaponsmith",
@@ -544,7 +969,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Repair and maintain weapons of all types. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "ranged_weaponsmith": {
       "name": "Ranged Weaponsmith",
@@ -552,7 +985,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Create ranged weapons. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "melee_weaponsmith": {
       "name": "Melee Weaponsmith",
@@ -560,7 +1001,15 @@
       "categoryId": "int_tech_skill",
       "cost": "+",
       "description": "Create melee weapons. [+1 Crafting]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.crafting",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     },
     "athletics": {
       "name": "Athletics",
@@ -568,7 +1017,15 @@
       "categoryId": "reflex",
       "cost": "+",
       "description": "Skill for throwing, climbing, and balancing. (+1 Luck)",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.luck",
+          "op": "add",
+          "value": 1,
+          "cap": 100
+        }
+      ]
     },
     "brawling": {
       "name": "Brawling",
@@ -616,7 +1073,15 @@
       "categoryId": "reflex",
       "cost": "+",
       "description": "Hide in shadows, move silently, evade guards. [+1 Evasion]",
-      "effects": []
+      "effects": [
+        {
+          "kind": "stat",
+          "target": "civil.evasion",
+          "op": "add",
+          "value": 1,
+          "cap": 50
+        }
+      ]
     }
   }
 }

--- a/src/lib/civilBonuses.ts
+++ b/src/lib/civilBonuses.ts
@@ -1,0 +1,114 @@
+import tagsData from "../data/constants/tags.json";
+import type {
+  CivilAttributeKey,
+  TagChoices,
+  TagSelections,
+} from "../types/character";
+
+type TagEffect = {
+  kind?: string;
+  target?: string;
+  op?: string;
+  value?: number;
+};
+
+type TagChoice = {
+  id?: string;
+  label?: string;
+  effects?: TagEffect[];
+};
+
+type TagItem = {
+  name: string;
+  effects?: TagEffect[];
+  choices?: TagChoice[];
+};
+
+type TagsJson = {
+  items?: Record<string, TagItem>;
+};
+
+export type CivilBonusSource = {
+  label: string;
+  values: Partial<Record<CivilAttributeKey, number>>;
+};
+
+const TAGS = tagsData as TagsJson;
+const TAG_ITEMS_BY_NAME = Object.values(TAGS.items ?? {}).reduce<
+  Record<string, TagItem>
+>((acc, item) => {
+  if (item?.name) {
+    acc[item.name] = item;
+  }
+  return acc;
+}, {});
+
+const CIVIL_TARGETS: Record<string, CivilAttributeKey> = {
+  "civil.reputation": "reputation",
+  "civil.empathy": "empathy",
+  "civil.appeal": "appeal",
+  "civil.performance": "performance",
+  "civil.crafting": "crafting",
+  "civil.driving": "driving",
+  "civil.evasion": "evasion",
+  "civil.intimidation": "intimidation",
+  "civil.luck": "luck",
+  "civil.perception": "perception",
+  "civil.persuasion": "persuasion",
+  "civil.tolerance": "tolerance",
+};
+
+export function getCivilTagBonusSources(
+  selections: TagSelections,
+  choices: TagChoices = {}
+): CivilBonusSource[] {
+  const sources: CivilBonusSource[] = [];
+
+  Object.entries(selections).forEach(([name, enabled]) => {
+    if (!enabled) return;
+    const tag = TAG_ITEMS_BY_NAME[name];
+    if (!tag) return;
+    const values: Partial<Record<CivilAttributeKey, number>> = {};
+    const applyEffects = (effects?: TagEffect[]) => {
+      if (!effects) return;
+      effects.forEach(effect => {
+        if (effect.kind !== "stat") return;
+        if (effect.op && effect.op !== "add") return;
+        const target = effect.target ? CIVIL_TARGETS[effect.target] : null;
+        if (!target) return;
+        const value = Number(effect.value);
+        if (!Number.isFinite(value) || value === 0) return;
+        values[target] = (values[target] ?? 0) + value;
+      });
+    };
+
+    applyEffects(tag.effects);
+    const choiceId = choices[name];
+    if (choiceId && tag.choices?.length) {
+      const choice =
+        tag.choices.find(option => option.id === choiceId) ??
+        tag.choices.find(option => option.label === choiceId);
+      applyEffects(choice?.effects);
+    }
+    if (Object.keys(values).length > 0) {
+      sources.push({ label: name, values });
+    }
+  });
+
+  return sources;
+}
+
+export function sumCivilBonusSources(
+  sources: CivilBonusSource[]
+): Partial<Record<CivilAttributeKey, number>> {
+  const totals: Partial<Record<CivilAttributeKey, number>> = {};
+  sources.forEach(source => {
+    Object.entries(source.values).forEach(([key, value]) => {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) return;
+      const attr = key as CivilAttributeKey;
+      totals[attr] = (totals[attr] ?? 0) + numeric;
+    });
+  });
+  return totals;
+}

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -19,6 +19,37 @@ export const ATTRIBUTE_KEYS: AttributeKey[] = [
   "technical",
 ];
 
+export type CivilAttributeKey =
+  | "reputation"
+  | "empathy"
+  | "appeal"
+  | "performance"
+  | "crafting"
+  | "driving"
+  | "evasion"
+  | "intimidation"
+  | "luck"
+  | "perception"
+  | "persuasion"
+  | "tolerance";
+
+export type CivilAttributes = Record<CivilAttributeKey, number>;
+
+export const CIVIL_ATTRIBUTE_KEYS: CivilAttributeKey[] = [
+  "reputation",
+  "empathy",
+  "appeal",
+  "performance",
+  "crafting",
+  "driving",
+  "evasion",
+  "intimidation",
+  "luck",
+  "perception",
+  "persuasion",
+  "tolerance",
+];
+
 export const WEAPON_TYPES = [
   "Unarmed Melee",
   "Blunt Weapon Melee",
@@ -48,6 +79,7 @@ export type WeaponConfig = {
 };
 
 export type TagSelections = Record<string, boolean>;
+export type TagChoices = Record<string, string>;
 export type StatusSelections = Record<string, boolean>;
 
 export type CyberModSystemState = {
@@ -57,12 +89,21 @@ export type CyberModSystemState = {
 
 export type CyberModsState = Record<string, CyberModSystemState>;
 
+export type OriginSelection = {
+  id: string | null;
+  allocations: Partial<Record<CivilAttributeKey, number>>;
+  choiceTags: string[];
+};
+
 export type Character = {
   id: string;
   name: string;
   attributes: Attributes;
+  civilAttributes: CivilAttributes;
   tags: TagSelections;
+  tagChoices: TagChoices;
   statusEffects: StatusSelections;
   weapon: WeaponConfig;
   cyberMods: CyberModsState;
+  origin: OriginSelection;
 };


### PR DESCRIPTION
closes #26
- added civil attributes, new card on the main page that lists non combative skills. Will implement cleaner ui  later. 
- added the new origins tab, allows users to select and commit to one origin that'll give them bonuses to their civil attributes
- changed the info box to include all selected cyber mods and tags
- added new + and - buttons 


need to implement feats and traits. 